### PR TITLE
Fix imports and installation instructions in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ package main
 import (
 	"time"
 
-	"github.com/kidoman/embd"
-	_ "github.com/kidoman/embd/host/rpi" // This loads the RPi driver
+	"github.com/tve/embd"
+	_ "github.com/tve/embd/host/rpi" // This loads the RPi driver
 )
 
 func main() {
@@ -71,7 +71,7 @@ Then run the program with ```sudo```*:
 * Assuming your RaspberryPi has an IP address of ```192.168.2.2```. Substitute as necessary
 * ```sudo``` (root) permission is required as we are controlling the hardware by writing to special files
 * This sample program is optimized for brevity and does not clean up after itself. Click here to
-  see the [full version](https://github.com/kidoman/embd/blob/master/samples/fullblinker.go)
+  see the [full version](https://github.com/tve/embd/blob/master/samples/fullblinker.go)
 
 ## Getting Help
 
@@ -90,7 +90,7 @@ Join the [mailing list](https://groups.google.com/forum/#!forum/go-embd)
 
 ## The command line tool
 
-	go get github.com/kidoman/embd/embd
+	go get github.com/tve/embd/embd
 
 will install a command line utility ```embd``` which will allow you to quickly get started with prototyping. The binary should be available in your ```$GOPATH/bin```. However, to be able to run this on a ARM based device, you will need to build it with ```GOOS=linux``` and ```GOARCH=arm``` environment variables set.
 
@@ -110,14 +110,14 @@ Package **embd** provides a hardware abstraction layer for doing embedded progra
 on supported platforms like the Raspberry Pi and BeagleBone Black. Most of the examples below
 will work without change (i.e. the same binary) on all supported platforms. How cool is that?
 
-Although samples are all present in the [samples](https://github.com/kidoman/embd/tree/master/samples) folder,
+Although samples are all present in the [samples](https://github.com/tve/embd/tree/master/samples) folder,
 we will show a few choice examples here.
 
 Use the **LED** driver to toggle LEDs on the BBB:
 
 ```go
-import "github.com/kidoman/embd"
-import _ "github.com/kidoman/embd/host/all"
+import "github.com/tve/embd"
+import _ "github.com/tve/embd/host/all"
 ...
 embd.InitLED()
 defer embd.CloseLED()
@@ -130,8 +130,8 @@ led.Toggle()
 Even shorter when quickly trying things out:
 
 ```go
-import "github.com/kidoman/embd"
-import _ "github.com/kidoman/embd/host/all"
+import "github.com/tve/embd"
+import _ "github.com/tve/embd/host/all"
 ...
 embd.InitLED()
 defer embd.CloseLED()
@@ -144,8 +144,8 @@ embd.ToggleLED(3)
 BBB + **PWM**:
 
 ```go
-import "github.com/kidoman/embd"
-import _ "github.com/kidoman/embd/host/all"
+import "github.com/tve/embd"
+import _ "github.com/tve/embd/host/all"
 ...
 embd.InitGPIO()
 defer embd.CloseGPIO()
@@ -159,8 +159,8 @@ pwm.SetDuty(1000)
 Control **GPIO** pins on the RaspberryPi / BeagleBone Black:
 
 ```go
-import "github.com/kidoman/embd"
-import _ "github.com/kidoman/embd/host/all"
+import "github.com/tve/embd"
+import _ "github.com/tve/embd/host/all"
 ...
 embd.InitGPIO()
 defer embd.CloseGPIO()
@@ -172,8 +172,8 @@ embd.DigitalWrite(10, embd.High)
 Could also do:
 
 ```go
-import "github.com/kidoman/embd"
-import _ "github.com/kidoman/embd/host/all"
+import "github.com/tve/embd"
+import _ "github.com/tve/embd/host/all"
 ...
 embd.InitGPIO()
 defer embd.CloseGPIO()
@@ -187,9 +187,9 @@ pin.Write(embd.High)
 Or read data from the **Bosch BMP085** barometric sensor:
 
 ```go
-import "github.com/kidoman/embd"
-import "github.com/kidoman/embd/sensor/bmp085"
-import _ "github.com/kidoman/embd/host/all"
+import "github.com/tve/embd"
+import "github.com/tve/embd/sensor/bmp085"
+import _ "github.com/tve/embd/host/all"
 ...
 bus := embd.NewI2CBus(1)
 ...
@@ -202,9 +202,9 @@ altitude, err := baro.Altitude()
 Even find out the heading from the **LSM303** magnetometer:
 
 ```go
-import "github.com/kidoman/embd"
-import "github.com/kidoman/embd/sensor/lsm303"
-import _ "github.com/kidoman/embd/host/all"
+import "github.com/tve/embd"
+import "github.com/tve/embd/sensor/lsm303"
+import _ "github.com/tve/embd/host/all"
 ...
 bus := embd.NewI2CBus(1)
 ...
@@ -231,8 +231,8 @@ A simple demo to blink an LED connected with a small resistor between XIO-P6 and
 package main
 import (
 	"time"
-	"github.com/kidoman/embd"
-	_ "github.com/kidoman/embd/host/chip"
+	"github.com/tve/embd"
+	_ "github.com/tve/embd/host/chip"
 )
 
 func main() {
@@ -252,28 +252,28 @@ Run it as root: `sudo ./blinky`
 
 ## Protocols Supported
 
-* **Digital GPIO** [Documentation](http://godoc.org/github.com/kidoman/embd#DigitalPin)
-* **Analog GPIO** [Documentation](http://godoc.org/github.com/kidoman/embd#AnalogPin)
-* **PWM** [Documentation](http://godoc.org/github.com/kidoman/embd#PWMPin)
-* **I2C** [Documentation](http://godoc.org/github.com/kidoman/embd#I2CBus)
-* **LED** [Documentation](http://godoc.org/github.com/kidoman/embd#LED)
-* **SPI** [Documentation](http://godoc.org/github.com/kidoman/embd#SPIBus)
+* **Digital GPIO** [Documentation](http://godoc.org/github.com/tve/embd#DigitalPin)
+* **Analog GPIO** [Documentation](http://godoc.org/github.com/tve/embd#AnalogPin)
+* **PWM** [Documentation](http://godoc.org/github.com/tve/embd#PWMPin)
+* **I2C** [Documentation](http://godoc.org/github.com/tve/embd#I2CBus)
+* **LED** [Documentation](http://godoc.org/github.com/tve/embd#LED)
+* **SPI** [Documentation](http://godoc.org/github.com/tve/embd#SPIBus)
 
 ## Sensors Supported
 
-* **TMP006** Thermopile sensor [Documentation](http://godoc.org/github.com/kidoman/embd/sensor/tmp006), [Datasheet](http://www.adafruit.com/datasheets/tmp006.pdf), [Userguide](http://www.adafruit.com/datasheets/tmp006ug.pdf)
+* **TMP006** Thermopile sensor [Documentation](http://godoc.org/github.com/tve/embd/sensor/tmp006), [Datasheet](http://www.adafruit.com/datasheets/tmp006.pdf), [Userguide](http://www.adafruit.com/datasheets/tmp006ug.pdf)
 
-* **BMP085** Barometric pressure sensor [Documentation](http://godoc.org/github.com/kidoman/embd/sensor/bmp085), [Datasheet](https://www.sparkfun.com/datasheets/Components/General/BST-BMP085-DS000-05.pdf)
+* **BMP085** Barometric pressure sensor [Documentation](http://godoc.org/github.com/tve/embd/sensor/bmp085), [Datasheet](https://www.sparkfun.com/datasheets/Components/General/BST-BMP085-DS000-05.pdf)
 
-* **BMP180** Barometric pressure sensor [Documentation](http://godoc.org/github.com/kidoman/embd/sensor/bmp180), [Datasheet](http://www.adafruit.com/datasheets/BST-BMP180-DS000-09.pdf)
+* **BMP180** Barometric pressure sensor [Documentation](http://godoc.org/github.com/tve/embd/sensor/bmp180), [Datasheet](http://www.adafruit.com/datasheets/BST-BMP180-DS000-09.pdf)
 
-* **LSM303** Accelerometer and magnetometer [Documentation](http://godoc.org/github.com/kidoman/embd/sensor/lsm303), [Datasheet](https://www.sparkfun.com/datasheets/Sensors/Magneto/LSM303%20Datasheet.pdf)
+* **LSM303** Accelerometer and magnetometer [Documentation](http://godoc.org/github.com/tve/embd/sensor/lsm303), [Datasheet](https://www.sparkfun.com/datasheets/Sensors/Magneto/LSM303%20Datasheet.pdf)
 
-* **L3GD20** Gyroscope [Documentation](http://godoc.org/github.com/kidoman/embd/sensor/l3gd20), [Datasheet](http://www.adafruit.com/datasheets/L3GD20.pdf)
+* **L3GD20** Gyroscope [Documentation](http://godoc.org/github.com/tve/embd/sensor/l3gd20), [Datasheet](http://www.adafruit.com/datasheets/L3GD20.pdf)
 
-* **US020** Ultrasonic proximity sensor [Documentation](http://godoc.org/github.com/kidoman/embd/sensor/us020), [Product Page](http://www.digibay.in/sensor/object-detection-and-proximity?product_id=239)
+* **US020** Ultrasonic proximity sensor [Documentation](http://godoc.org/github.com/tve/embd/sensor/us020), [Product Page](http://www.digibay.in/sensor/object-detection-and-proximity?product_id=239)
 
-* **BH1750FVI** Luminosity sensor [Documentation](http://godoc.org/github.com/kidoman/embd/sensor/bh1750fvi), [Datasheet](http://www.elechouse.com/elechouse/images/product/Digital%20light%20Sensor/bh1750fvi-e.pdf)
+* **BH1750FVI** Luminosity sensor [Documentation](http://godoc.org/github.com/tve/embd/sensor/bh1750fvi), [Datasheet](http://www.elechouse.com/elechouse/images/product/Digital%20light%20Sensor/bh1750fvi-e.pdf)
 
 ## Interfaces
 
@@ -281,11 +281,11 @@ Run it as root: `sudo ./blinky`
 
 ## Controllers
 
-* **PCA9685** 16-channel, 12-bit PWM Controller with I2C protocol [Documentation](http://godoc.org/github.com/kidoman/embd/controller/pca9685), [Datasheet](http://www.adafruit.com/datasheets/PCA9685.pdf), [Product Page](http://www.adafruit.com/products/815)
+* **PCA9685** 16-channel, 12-bit PWM Controller with I2C protocol [Documentation](http://godoc.org/github.com/tve/embd/controller/pca9685), [Datasheet](http://www.adafruit.com/datasheets/PCA9685.pdf), [Product Page](http://www.adafruit.com/products/815)
 
-* **MCP4725** 12-bit DAC [Documentation](http://godoc.org/github.com/kidoman/embd/controller/mcp4725), [Datasheet](http://www.adafruit.com/datasheets/mcp4725.pdf), [Product Page](http://www.adafruit.com/products/935)
+* **MCP4725** 12-bit DAC [Documentation](http://godoc.org/github.com/tve/embd/controller/mcp4725), [Datasheet](http://www.adafruit.com/datasheets/mcp4725.pdf), [Product Page](http://www.adafruit.com/products/935)
 
-* **ServoBlaster** RPi PWM/PCM based PWM controller [Documentation](http://godoc.org/github.com/kidoman/embd/controller/servoblaster), [Product Page](https://github.com/richardghirst/PiBits/tree/master/ServoBlaster)
+* **ServoBlaster** RPi PWM/PCM based PWM controller [Documentation](http://godoc.org/github.com/tve/embd/controller/servoblaster), [Product Page](https://github.com/richardghirst/PiBits/tree/master/ServoBlaster)
 
 ## Convertors
 
@@ -293,9 +293,9 @@ Run it as root: `sudo ./blinky`
 
 ## Contributing
 
-We look forward to your pull requests, but contributions which abide by the [guidelines](https://github.com/kidoman/embd/blob/master/CONTRIBUTING.md) will get a free beer!
+We look forward to your pull requests, but contributions which abide by the [guidelines](https://github.com/tve/embd/blob/master/CONTRIBUTING.md) will get a free beer!
 
-File an [issue](https://github.com/kidoman/embd/issues), open a [pull request](https://github.com/kidoman/embd/pulls). We are waiting.
+File an [issue](https://github.com/tve/embd/issues), open a [pull request](https://github.com/tve/embd/pulls). We are waiting.
 
 ## About
 


### PR DESCRIPTION
As Kidoman's repository is abandoned I think it's a good idea to fix README with proper links to your fork.
